### PR TITLE
Use constant name when using Config::get()

### DIFF
--- a/BetterYouTubeRss.php
+++ b/BetterYouTubeRss.php
@@ -31,7 +31,7 @@ try {
 
 		if ($cache->expired($part)) {
 
-			if (Config::get('HybridMode') === true && $part === 'playlist') {
+			if (Config::get('ENABLE_HYBRID_MODE') === true && $part === 'playlist') {
 				$parameter = $betterRss->getChannelId();
 			}
 

--- a/include/Cache.class.php
+++ b/include/Cache.class.php
@@ -51,7 +51,7 @@ class Cache {
 	 */
 	public function load() {
 
-		if (Config::get('DisableCache') === true) {
+		if (Config::get('DISABLE_CACHE') === true) {
 			return false;
 		}
 
@@ -76,7 +76,7 @@ class Cache {
 
 		$ExpiredVideos = array();
 
-		if (empty($this->data['videos']['items']) || Config::get('DisableCache') === true) {
+		if (empty($this->data['videos']['items']) || Config::get('DISABLE_CACHE') === true) {
 			return implode(',', $this->data['playlist']['videos']);
 		}
 
@@ -97,7 +97,7 @@ class Cache {
 	 */
 	public function expired(string $part) {
 
-		if (Config::get('DisableCache') === true) {
+		if (Config::get('DISABLE_CACHE') === true) {
 			return true;
 		}
 
@@ -167,8 +167,8 @@ class Cache {
 	 * Set cache file path
 	 */
 	private function setPath() {
-		$this->path = Config::get('AbsolutePath') . DIRECTORY_SEPARATOR . 
-			Config::get('CacheDirectory') . DIRECTORY_SEPARATOR . $this->name . '.' . Config::get('CacheFilenameExt');
+		$this->path = Config::get('ABSOLUTE_PATH') . DIRECTORY_SEPARATOR . 
+			Config::get('CacheDirectory') . DIRECTORY_SEPARATOR . $this->name . '.' . Config::get('CACHE_FILENAME_EXT'');
 	}
 
 	/**

--- a/include/Cache.class.php
+++ b/include/Cache.class.php
@@ -168,7 +168,7 @@ class Cache {
 	 */
 	private function setPath() {
 		$this->path = Config::get('ABSOLUTE_PATH') . DIRECTORY_SEPARATOR . 
-			Config::get('CacheDirectory') . DIRECTORY_SEPARATOR . $this->name . '.' . Config::get('CACHE_FILENAME_EXT'');
+			Config::get('CACHE_DIR') . DIRECTORY_SEPARATOR . $this->name . '.' . Config::get('CACHE_FILENAME_EXT');
 	}
 
 	/**

--- a/include/CacheViewer.class.php
+++ b/include/CacheViewer.class.php
@@ -30,7 +30,7 @@ class CacheViewer {
 	 * Constructor
 	 *
 	 * @throws Exception if EnableCacheViewer is false
-	 * @throws Exception if DisableCache is true
+	 * @throws Exception if DISABLE_CACHE is true
 	 */
 	public function __construct() {
 
@@ -38,7 +38,7 @@ class CacheViewer {
 			throw new Exception('Cache viewer is disabled.');
 		}
 
-		if (Config::get('DisableCache') === true) {
+		if (Config::get('DISABLE_CACHE') === true) {
 			throw new Exception('Cache viewer not available. Cache is disabled.');
 		}
 
@@ -80,9 +80,9 @@ class CacheViewer {
 	 */
 	private function loadFiles() {
 
-		$regex = '/.' . preg_quote(Config::get('CacheFilenameExt')) . '$/';
+		$regex = '/.' . preg_quote(Config::get('CACHE_FILENAME_EXT'')) . '$/';
 
-		$directoryPath = Config::get('AbsolutePath') . DIRECTORY_SEPARATOR . Config::get('CacheDirectory');
+		$directoryPath = Config::get('ABSOLUTE_PATH') . DIRECTORY_SEPARATOR . Config::get('CacheDirectory');
 		$cacheDirectory = new RecursiveDirectoryIterator($directoryPath);
 		$cacheFiles = new RegexIterator($cacheDirectory, $regex);
 
@@ -102,7 +102,7 @@ class CacheViewer {
 
 			$data = json_decode($contents, true);
 			$this->data[] = array(
-				'id' => $file->getBasename('.' . Config::get('CacheFilenameExt')),
+				'id' => $file->getBasename('.' . Config::get('CACHE_FILENAME_EXT'')),
 				'modified' => $file->getMTime(),
 				'size' => $file->getSize(),
 				'contents' => $data

--- a/include/CacheViewer.class.php
+++ b/include/CacheViewer.class.php
@@ -29,12 +29,12 @@ class CacheViewer {
 	/**
 	 * Constructor
 	 *
-	 * @throws Exception if EnableCacheViewer is false
+	 * @throws Exception if ENABLE_CACHE_VIEWER is false
 	 * @throws Exception if DISABLE_CACHE is true
 	 */
 	public function __construct() {
 
-		if (!Config::get('EnableCacheViewer')) {
+		if (!Config::get('ENABLE_CACHE_VIEWER')) {
 			throw new Exception('Cache viewer is disabled.');
 		}
 
@@ -80,9 +80,9 @@ class CacheViewer {
 	 */
 	private function loadFiles() {
 
-		$regex = '/.' . preg_quote(Config::get('CACHE_FILENAME_EXT'')) . '$/';
+		$regex = '/.' . preg_quote(Config::get('CACHE_FILENAME_EXT')) . '$/';
 
-		$directoryPath = Config::get('ABSOLUTE_PATH') . DIRECTORY_SEPARATOR . Config::get('CacheDirectory');
+		$directoryPath = Config::get('ABSOLUTE_PATH') . DIRECTORY_SEPARATOR . Config::get('CACHE_DIR');
 		$cacheDirectory = new RecursiveDirectoryIterator($directoryPath);
 		$cacheFiles = new RegexIterator($cacheDirectory, $regex);
 
@@ -102,7 +102,7 @@ class CacheViewer {
 
 			$data = json_decode($contents, true);
 			$this->data[] = array(
-				'id' => $file->getBasename('.' . Config::get('CACHE_FILENAME_EXT'')),
+				'id' => $file->getBasename('.' . Config::get('CACHE_FILENAME_EXT')),
 				'modified' => $file->getMTime(),
 				'size' => $file->getSize(),
 				'contents' => $data

--- a/include/Config.class.php
+++ b/include/Config.class.php
@@ -121,6 +121,6 @@ class Config {
 			throw new Exception('Invalid config key given:' . $key);
 		}
 
-		return constant(self::$keys[$key]);
+		return constant($key);
 	}
 }

--- a/include/Config.class.php
+++ b/include/Config.class.php
@@ -2,22 +2,6 @@
 
 class Config {
 
-	private static $keys = array(
-		'AbsolutePath' => 'ABSOLUTE_PATH',
-		'SelfUrlPath' => 'SELF_URL_PATH',
-		'YouTubeApiKey' => 'YOUTUBE_API_KEY',
-		'YouTubeEmbedPrivacy' => 'YOUTUBE_EMBED_PRIVACY',
-		'RawApiErrors' => 'RAW_API_ERRORS',
-		'Timezone' => 'TIMEZONE',
-		'DateFormat' => 'DATE_FORMAT',
-		'ResultsLimit' => 'RESULTS_LIMIT',
-		'CacheDirectory' => 'CACHE_DIR',
-		'CacheFilenameExt' => 'CACHE_FILENAME_EXT',
-		'DisableCache' => 'DISABLE_CACHE',
-		'EnableCacheViewer' => 'ENABLE_CACHE_VIEWER',
-		'HybridMode' => 'ENABLE_HYBRID_MODE'
-	);
-
 	/** @var string $minPhpVersion Minimum PHP version */
 	private static $minPhpVersion = '7.1.0';
 	

--- a/include/Config.class.php
+++ b/include/Config.class.php
@@ -117,7 +117,7 @@ class Config {
 	 */
 	public static function get(string $key) {
 
-		if (!isset(self::$keys[$key])) {
+		if (!defined($key)) {
 			throw new Exception('Invalid config key given:' . $key);
 		}
 

--- a/include/Feed.class.php
+++ b/include/Feed.class.php
@@ -130,7 +130,7 @@ EOD;
 	private function buildContent(array $video) {
 
 		$description = $this->formatDescription($video['description']);
-		$published = Helper::convertUnixTime($video['published'], config::get('DateFormat'));
+		$published = Helper::convertUnixTime($video['published'], config::get('DATE_FORMAT'));
 
 		$media = <<<EOD
 <a target="_blank" title="Watch" href="https://youtube.com/watch?v={$video['id']}"><img src="{$video['thumbnail']}"/></a>

--- a/include/Feed.class.php
+++ b/include/Feed.class.php
@@ -139,7 +139,7 @@ EOD;
 		if ($this->embedVideos === true) {
 			$url = $this->embedUrl;
 
-			if (config::get('YouTubeEmbedPrivacy')) {
+			if (config::get('YOUTUBE_EMBED_PRIVACY')) {
 				$url = $this->embedUrlNoCookie;
 			}
 

--- a/include/FeedUrlGenerator.class.php
+++ b/include/FeedUrlGenerator.class.php
@@ -64,7 +64,7 @@ class FeedUrlGenerator {
 		$error = '';
 
 		if (!empty($this->channelId) && $this->error === false) {
-			$url = Config::get('SelfUrlPath') . 'BetterYouTubeRss.php?channel_id=' . $this->channelId;
+			$url = Config::get('SELF_URL_PATH') . 'BetterYouTubeRss.php?channel_id=' . $this->channelId;
 			$link = <<<HTML
 <p>Feed URL: <a href="{$url}">{$url}</a></p>
 HTML;
@@ -140,7 +140,7 @@ HTML;
 		try {
 
 			$url = 'https://www.googleapis.com/youtube/v3/search?part=snippet&fields=items(snippet(channelId))&q=' .
-				urlencode($query) . '&type=channel&maxResults=1&prettyPrint=false&key=' . Config::get('YouTubeApiKey');
+				urlencode($query) . '&type=channel&maxResults=1&prettyPrint=false&key=' . Config::get('YOUTUBE_API_KEY');
 
 			$curl = new Curl();
 			$curl->get($url);

--- a/include/Fetch.class.php
+++ b/include/Fetch.class.php
@@ -238,7 +238,7 @@ class Fetch {
 		}
 
 		if ($this->fetchType === 'playlist') {
-			$parameters = 'playlistItems?part=contentDetails&maxResults=' . Config::get('ResultsLimit') . '&playlistId='
+			$parameters = 'playlistItems?part=contentDetails&maxResults=' . Config::get('RESULTS_LIMIT') . '&playlistId='
 				. $this->data['channel']['playlist'] . '&fields=etag,items(contentDetails(videoId))';
 		}
 
@@ -249,7 +249,7 @@ class Fetch {
 				. $ids . '&fields=etag,items(id,snippet(title,description,tags,publishedAt,thumbnails(standard(url),maxres(url))),contentDetails(duration))';
 		}
 
-		return $this->endpoint . $parameters . '&prettyPrint=false&key=' . Config::get('YouTubeApiKey');
+		return $this->endpoint . $parameters . '&prettyPrint=false&key=' . Config::get('YOUTUBE_API_KEY');
 	}
 
 	/**
@@ -261,7 +261,7 @@ class Fetch {
 	private function handleApiError($response) {
 		$error = $response->error->errors[0];
 
-		if (config::get('RawApiErrors') === true) {
+		if (config::get('RAW_API_ERRORS') === true) {
 			$raw = json_encode($response->error, JSON_PRETTY_PRINT);
 
 			throw new Exception(

--- a/include/Fetch.class.php
+++ b/include/Fetch.class.php
@@ -50,7 +50,7 @@ class Fetch {
 		$this->fetchType = $part;
 		$etag = '';
 
-		if (Config::get('HybridMode') === true && $part === 'playlist') {
+		if (Config::get('ENABLE_HYBRID_MODE') === true && $part === 'playlist') {
 			$this->fetchType = 'feed';
 			$response = $this->fetchFeed($parameter);
 

--- a/include/helper.class.php
+++ b/include/helper.class.php
@@ -63,7 +63,7 @@ class Helper {
 	public static function convertUnixTime(int $timestamp = 0, string $format = 'Y-m-d H:i:s') {
 		$dt = new DateTime();
 		$dt->setTimestamp($timestamp);
-		$dt->setTimezone(new DateTimeZone(config::get('Timezone')));
+		$dt->setTimezone(new DateTimeZone(config::get('TIMEZONE')));
 
 		return $dt->format($format);
 	}


### PR DESCRIPTION
Removes `keys` array from config.class.php and updates files to use constant name when using `Config::get()`.  e.g: `Config::get('HybridMode') -> Config::get('ENABLE_HYBRID_MODE')`