### PR TITLE
[Format] Remove 'abstract' keyword from buildContent()

### DIFF
--- a/include/Format.class.php
+++ b/include/Format.class.php
@@ -61,7 +61,32 @@ abstract class Format {
 	 *
 	 * @param array $video Video data
 	 */
-	abstract protected function buildContent(array $video);
+	protected function buildContent(array $video) {
+		
+		$description = $this->formatDescription($video['description']);
+		$published = Helper::convertUnixTime($video['published'], config::get('DATE_FORMAT'));
+
+		$media = <<<EOD
+<a target="_blank" title="Watch" href="https://youtube.com/watch?v={$video['id']}"><img src="{$video['thumbnail']}"/></a>
+EOD;
+
+		if ($this->embedVideos === true) {
+			$url = $this->embedUrl;
+
+			if (config::get('YOUTUBE_EMBED_PRIVACY')) {
+				$url = $this->embedUrlNoCookie;
+			}
+
+		$media = <<<EOD
+<iframe width="100%" height="410" src="{$url}/embed/{$video['id']}" frameborder="0" allow="encrypted-media;" allowfullscreen></iframe>
+EOD;
+		}
+
+		return <<<EOD
+<a target="_blank" title="Watch" href="https://youtube.com/watch?v={$video['id']}">{$media}</a>
+<hr/>Published: {$published} - Duration: {$video['duration']}<hr/><p>{$description}</p>
+EOD;
+	}
 
 	/**
 	 * Format video description

--- a/include/HtmlFormat.class.php
+++ b/include/HtmlFormat.class.php
@@ -98,37 +98,4 @@ EOD;
 
 		return $itemCategories . '</ul>';
 	}
-
-	/**
-	 * Build item content (description)
-	 *
-	 * @param array $video Video data
-	 * @return string Item content as HTML
-	 */
-	protected function buildContent(array $video) {
-
-		$description = $this->formatDescription($video['description']);
-		$published = Helper::convertUnixTime($video['published'], config::get('DATE_FORMAT'));
-
-		$media = <<<EOD
-<a target="_blank" title="Watch" href="https://youtube.com/watch?v={$video['id']}"><img src="{$video['thumbnail']}"/></a>
-EOD;
-
-		if ($this->embedVideos === true) {
-			$url = $this->embedUrl;
-
-			if (config::get('YOUTUBE_EMBED_PRIVACY')) {
-				$url = $this->embedUrlNoCookie;
-			}
-
-		$media = <<<EOD
-<iframe width="100%" height="410" src="{$url}/embed/{$video['id']}" frameborder="0" allow="encrypted-media;" allowfullscreen></iframe>
-EOD;
-		}
-
-		return <<<EOD
-<a target="_blank" title="Watch" href="https://youtube.com/watch?v={$video['id']}">{$media}</a>
-<hr/>Published: {$published} - Duration: {$video['duration']}<hr/><p>{$description}</p>
-EOD;
-	}
 }

--- a/include/JsonFormat.class.php
+++ b/include/JsonFormat.class.php
@@ -74,37 +74,4 @@ class JsonFormat extends Format {
 	protected function buildCategories(array $categories) {
 		return $categories;
 	}
-
-	/**
-	 * Build item content (description)
-	 *
-	 * @param array $video Video data
-	 * @return string Item content as HTML
-	 */
-	protected function buildContent(array $video) {
-
-		$description = $this->formatDescription($video['description']);
-		$published = Helper::convertUnixTime($video['published'], config::get('DATE_FORMAT'));
-
-		$media = <<<EOD
-<img src="{$video['thumbnail']}"/>
-EOD;
-
-		if ($this->embedVideos === true) {
-			$url = $this->embedUrl;
-
-			if (config::get('YOUTUBE_EMBED_PRIVACY')) {
-				$url = $this->embedUrlNoCookie;
-			}
-
-		$media = <<<EOD
-<iframe width="100%" height="410" src="{$url}/embed/{$video['id']}" frameborder="0" allow="encrypted-media;" allowfullscreen></iframe>
-EOD;
-		}
-
-		return <<<EOD
-<a target="_blank" title="Watch" href="https://youtube.com/watch?v={$video['id']}">{$media}</a>
-<hr/>Published: {$published} - Duration: {$video['duration']}<hr/><p>{$description}</p>
-EOD;
-	}
 }

--- a/include/XmlFormat.class.php
+++ b/include/XmlFormat.class.php
@@ -91,37 +91,4 @@ EOD;
 
 		return $itemCategories;
 	}
-
-	/**
-	 * Build item content (description)
-	 *
-	 * @param array $video Video data
-	 * @return string Item content as HTML
-	 */
-	protected function buildContent(array $video) {
-
-		$description = $this->formatDescription($video['description']);
-		$published = Helper::convertUnixTime($video['published'], config::get('DATE_FORMAT'));
-
-		$media = <<<EOD
-<img src="{$video['thumbnail']}"/>
-EOD;
-
-		if ($this->embedVideos === true) {
-			$url = $this->embedUrl;
-
-			if (config::get('YOUTUBE_EMBED_PRIVACY')) {
-				$url = $this->embedUrlNoCookie;
-			}
-
-		$media = <<<EOD
-<iframe width="100%" height="410" src="{$url}/embed/{$video['id']}" frameborder="0" allow="encrypted-media;" allowfullscreen></iframe>
-EOD;
-		}
-
-		return <<<EOD
-<a target="_blank" title="Watch" href="https://youtube.com/watch?v={$video['id']}">{$media}</a>
-<hr/>Published: {$published} - Duration: {$video['duration']}<hr/><p>{$description}</p>
-EOD;
-	}
 }


### PR DESCRIPTION
Remove `abstract` keyword from `buildContent()` in `Format` and remove the function from extended classes `HtmlFormat`, `XmlFormat` and `JsonFormat`. Code in `buildContent()` is not modified by the extended classes so there is no need to force extending classes to define the function.