### PR TITLE
[Helper] Add static function convertUrls()

### DIFF
--- a/include/Format.class.php
+++ b/include/Format.class.php
@@ -62,8 +62,6 @@ abstract class Format {
 	 * @param array $video Video data
 	 */
 	protected function buildContent(array $video) {
-		
-		$description = $this->formatDescription($video['description']);
 		$published = Helper::convertUnixTime($video['published'], config::get('DATE_FORMAT'));
 
 		$media = <<<EOD
@@ -85,32 +83,6 @@ EOD;
 		return <<<EOD
 {$media}<hr/>Published: {$published} - Duration: {$video['duration']}<hr/><p>{$description}</p>
 EOD;
-	}
-
-	/**
-	 * Format video description
-	 * Converts URLs to HTMl links
-	 *
-	 * @param string $description
-	 */
-	protected function formatDescription(string $description) {
-
-		if (empty($description)) {
-			return ' ';
-		}
-
-		$formatted = '';
-		$lines = explode("\n", $description);
-
-		foreach ($lines as $index => $line) {
-			if(preg_match($this->urlRegex, $line, $matches)) {
-				$line = str_replace($matches[0], '<a target="_blank" href="' . $matches[0] . '">' . $matches[0] . '</a>', $line);
-			}
-
-			$formatted .= $line . '<br/>';
-		}
-
-		return $formatted;
 	}
 
 	/**

--- a/include/Format.class.php
+++ b/include/Format.class.php
@@ -62,6 +62,9 @@ abstract class Format {
 	 * @param array $video Video data
 	 */
 	protected function buildContent(array $video) {
+
+		$description = nl2br($video['description']);
+		$description = Helper::convertUrls($description);
 		$published = Helper::convertUnixTime($video['published'], config::get('DATE_FORMAT'));
 
 		$media = <<<EOD

--- a/include/Helper.class.php
+++ b/include/Helper.class.php
@@ -1,6 +1,10 @@
 <?php
 
 class Helper {
+	
+	/** @var int $urlRegex URL regex */
+	private static $urlRegex = '/(https?:\/\/(?:www\.)?(?:[a-zA-Z0-9-.]{2,256}\.[a-z]{2,20})(\:[0-9]{2,4})?(?:\/[a-zA-Z0-9@:%_\+.,~#"!?&\/\/=\-*]+|\/)?)/ims';
+	
 	/**
 	 * Parse ISO 8601 video duration to hours, minutes and seconds
 	 *

--- a/include/Helper.class.php
+++ b/include/Helper.class.php
@@ -71,4 +71,19 @@ class Helper {
 
 		return $dt->format($format);
 	}
+
+	/**
+	 * Convert URLs to HTML links
+	 *
+	 * @param string $string
+	 * @return string
+	 */
+	public static function convertUrls(string $string) {
+
+		return preg_replace(
+			self::$urlRegex,
+			'<a href="$1" target="_blank">$1</a>',
+			$string
+		);
+	}
 }


### PR DESCRIPTION
This pull request adds the static function `convertUrls` to the `Helper` class and removes the function `formatDescription` from the `Format` class. The build-in function `nl2br` is used to inserts HTML line breaks before newlines, which was previously done in `formatDescription`.