### PR TITLE
Simplify feed format handling

### DIFF
--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -109,39 +109,19 @@ class BetterYouTubeRss {
 
 		$cache->save();
 
-		switch ($this->feedFormat) {
-			case 'rss':
-
-				$format = new XmlFormat(
-					$cache->getData(),
-					$this->getEmbedStatus()
-				);
-
-				$format->build();
-				Output::xml($format->get());
-
-				break;
-			case 'html':
-
-				$format = new HtmlFormat(
-					$cache->getData(),
-					$this->getEmbedStatus()
-				);
-
-				$format->build();
-				Output::html($format->get());
-
-				break;
-			case 'json':
-
-				$format = new JsonFormat(
-					$cache->getData(),
-					$this->getEmbedStatus()
-				);
-
-				$format->build();
-				Output::json($format->get());
+		if (!in_array($this->feedFormat, $this->getFeedFormats())) {
+			throw new Exception('Invalid format parameter given.');
 		}
+
+		$formatClass = ucfirst($this->feedFormat) . 'Format';
+
+		$format = new $formatClass(
+			$cache->getData(),
+			$this->getEmbedStatus()
+		);
+
+		$format->build();
+
 	}
 
 	public function generateIndex() {

--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -146,7 +146,9 @@ class BetterYouTubeRss {
 
 	public function generateIndex() {
 
-		$generator = new FeedUrlGenerator();
+		$generator = new FeedUrlGenerator(
+			$this->getFeedFormats()
+		);
 		$generator->display();
 
 	}

--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -162,6 +162,15 @@ class BetterYouTubeRss {
 	public function getFeedId() {
 		return $this->feedId;
 	}
+	
+	/**
+	 * Return supported feed formats
+	 *
+	 * @return string
+	 */
+	private function getFeedFormats() {
+		return $this->supportedFeedFormats;
+	}
 
 	/**
 	 * Return embed video status

--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -120,6 +120,10 @@ class BetterYouTubeRss {
 
 		$format->build();
 
+		Output::feed(
+			$format->get(),
+			$format->getContentType()
+		);
 	}
 
 	public function generateIndex() {

--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -32,12 +32,18 @@ class BetterYouTubeRss {
 	/**
 	 * Check user inputs
 	 *
+	 * @throws Exception if a invalid format parameter given.
 	 * @throws Exception if a empty channel ID parameter is given.
 	 * @throws Exception if a empty playlist ID parameter is given.
 	 */
 	private function checkInputs() {
 
-		if (isset($_GET['format']) && in_array($_GET['format'], $this->supportedFeedFormats)) {
+		if (isset($_GET['format'])) {
+
+			if (!in_array($_GET['format'], $this->getFeedFormats())) {
+				throw new Exception('Invalid format parameter given.');
+			}
+
 			$this->feedFormat = $_GET['format'];
 		}
 

--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -11,12 +11,10 @@ class BetterYouTubeRss {
 	/** @var boolean $embedVideos Embed videos status */
 	private $embedVideos = false;
 
-	/** @var string $feedFormat Feed format */
+	/** @var string $feedFormat Default feed format */
 	private $feedFormat = 'rss';
 
-	/**
-	 * @var array $supportedFormats Supported feed formats
-	 */
+	/** @var array $supportedFormats Supported feed formats */
 	private $supportedFeedFormats = array('rss', 'html', 'json');
 
 	/** @var array $parts Cache and fetch parts */

--- a/include/FeedUrlGenerator.class.php
+++ b/include/FeedUrlGenerator.class.php
@@ -38,9 +38,9 @@ class FeedUrlGenerator {
 	private $feedFormat = 'rss';
 
 	/**
-	 * @var array $supportedFormats Supported feed formats
+	 * @var array $supportedFormats Feed formats
 	 */
-	private $supportedFormats = array('rss', 'html', 'json');
+	private $supportedFormats = array();
 
 	/**
 	 * @var boolean $error Error status
@@ -55,7 +55,10 @@ class FeedUrlGenerator {
 	/**
 	 * Constructor
 	 */
-	public function __construct() {
+	public function __construct(array $supportedFormats) {
+
+		$this->supportedFormats = $supportedFormats;
+
 		$this->checkInputs();
 
 		if (!empty($this->query)) {

--- a/include/Format.class.php
+++ b/include/Format.class.php
@@ -7,6 +7,9 @@ abstract class Format {
 
 	/** @var string $feed Formatted feed data */
 	protected $feed = '';
+	
+	/** @var string $contentType HTTP content-type header value */
+	protected $contentType = 'text/plain';
 
 	/** @var string $urlRegex URL regex */
 	protected $urlRegex = '/https?:\/\/(?:www\.)?(?:[a-zA-Z0-9-.]{2,256}\.[a-z]{2,20})(\:[0-9]{2,4})?(?:\/[a-zA-Z0-9@:%_\+.,~#"!?&\/\/=\-*]+|\/)?/';

--- a/include/Format.class.php
+++ b/include/Format.class.php
@@ -42,6 +42,16 @@ abstract class Format {
 		return $this->feed;
 	}
 
+	
+	/**
+	 * Returns feed header
+	 *
+	 * @return string
+	 */
+	public function getContentType() {
+		return $this->contentType;
+	}
+
 	/**
 	 * Build feed itmes
 	 *

--- a/include/HtmlFormat.class.php
+++ b/include/HtmlFormat.class.php
@@ -1,6 +1,10 @@
 <?php
 
 class HtmlFormat extends Format {
+
+	/** @var string $contentType HTTP content-type header value */
+	protected $contentType = 'text/html; charset=UTF-8';
+
 	/**
 	 * Build feed
 	 */

--- a/include/JsonFormat.class.php
+++ b/include/JsonFormat.class.php
@@ -8,6 +8,10 @@
  * https://json-feed-validator.herokuapp.com/validate
  */
 class JsonFormat extends Format {
+
+	/** @var string $contentType HTTP content-type header value */
+	protected $contentType = 'application/json';
+
 	/**
 	 * Build feed
 	 */

--- a/include/Output.class.php
+++ b/include/Output.class.php
@@ -10,6 +10,21 @@ class Output {
 	}
 
 	/**
+	 * Output feed
+	 */	
+	
+	/**
+	 * Output feed
+	 *
+	 * @param string $data Feed data
+	 * @param string $contentType Content-type header value
+	 */
+	public static function feed(string $data, string $contentType) {
+		header('content-type: ' . $contentType);
+		echo $data;
+	}
+	
+	/**
 	 * Output XML
 	 */
 	public static function xml(string $feed) {

--- a/include/RssFormat.class.php
+++ b/include/RssFormat.class.php
@@ -1,6 +1,6 @@
 <?php
 
-class XmlFormat extends Format {
+class RssFormat extends Format {
 
 	/** @var string $contentType HTTP content-type header value */
 	protected $contentType = 'text/xml; charset=UTF-8';

--- a/include/XmlFormat.class.php
+++ b/include/XmlFormat.class.php
@@ -1,6 +1,10 @@
 <?php
 
 class XmlFormat extends Format {
+
+	/** @var string $contentType HTTP content-type header value */
+	protected $contentType = 'text/xml; charset=UTF-8';
+
 	/**
 	 * Build feed
 	 */


### PR DESCRIPTION
This pull request simplifies feed format handling, making it simpler add new formats. 

The array `$supportedFeedFormats` is now only in `BetterYouTubeRss` and can be accessed with `getFeedFormats()`. Each feed format can set its own `content-type` header value via ` $contentType`, removing the need for extra functions in `Output`.