### PR TITLE
[BetterYouTubeRss] Change function visibility (public -> private)

### DIFF
--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -88,7 +88,7 @@ class BetterYouTubeRss {
 	/**
 	 * Check user inputs
 	 *
-	 * @throws Exception if a invalid format parameter given.
+	 * @throws Exception if a invalid format parameter is given.
 	 * @throws Exception if a empty channel ID parameter is given.
 	 * @throws Exception if a empty playlist ID parameter is given.
 	 */
@@ -128,6 +128,9 @@ class BetterYouTubeRss {
 		}
 	}
 
+	/**
+	 * Generate feed
+	 */
 	private function generateFeed() {
 
 		$cache = new Cache(
@@ -184,6 +187,9 @@ class BetterYouTubeRss {
 		);
 	}
 
+	/**
+	 * Generate index page with FeedUrlGenerator
+	 */
 	private function generateIndex() {
 
 		$generator = new FeedUrlGenerator(

--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -41,6 +41,51 @@ class BetterYouTubeRss {
 	}
 
 	/**
+	 * Return Feed type
+	 *
+	 * @return string
+	 */
+	private function getFeedType() {
+		return $this->feedType;
+	}
+
+	/**
+	 * Return feed ID
+	 *
+	 * @return string
+	 */
+	private function getFeedId() {
+		return $this->feedId;
+	}
+	
+	/**
+	 * Return supported feed formats
+	 *
+	 * @return string
+	 */
+	private function getFeedFormats() {
+		return $this->supportedFeedFormats;
+	}
+
+	/**
+	 * Return embed video status
+	 *
+	 * @return boolean
+	 */
+	private function getEmbedStatus() {
+		return $this->embedVideos;
+	}
+
+	/**
+	 * Return cache and fetch parts
+	 *
+	 * @return array
+	 */
+	private function getParts() {
+		return $this->parts;
+	}
+	
+	/**
 	 * Check user inputs
 	 *
 	 * @throws Exception if a invalid format parameter given.
@@ -146,50 +191,5 @@ class BetterYouTubeRss {
 		);
 		$generator->display();
 
-	}
-
-	/**
-	 * Return Feed type
-	 *
-	 * @return string
-	 */
-	private function getFeedType() {
-		return $this->feedType;
-	}
-
-	/**
-	 * Return feed ID
-	 *
-	 * @return string
-	 */
-	private function getFeedId() {
-		return $this->feedId;
-	}
-	
-	/**
-	 * Return supported feed formats
-	 *
-	 * @return string
-	 */
-	private function getFeedFormats() {
-		return $this->supportedFeedFormats;
-	}
-
-	/**
-	 * Return embed video status
-	 *
-	 * @return boolean
-	 */
-	private function getEmbedStatus() {
-		return $this->embedVideos;
-	}
-
-	/**
-	 * Return cache and fetch parts
-	 *
-	 * @return array
-	 */
-	private function getParts() {
-		return $this->parts;
 	}
 }

--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -83,7 +83,7 @@ class BetterYouTubeRss {
 		}
 	}
 
-	public function generateFeed() {
+	private function generateFeed() {
 
 		$cache = new Cache(
 			$this->getFeedId(),
@@ -139,7 +139,7 @@ class BetterYouTubeRss {
 		);
 	}
 
-	public function generateIndex() {
+	private function generateIndex() {
 
 		$generator = new FeedUrlGenerator(
 			$this->getFeedFormats()
@@ -153,7 +153,7 @@ class BetterYouTubeRss {
 	 *
 	 * @return string
 	 */
-	public function getFeedType() {
+	private function getFeedType() {
 		return $this->feedType;
 	}
 
@@ -162,7 +162,7 @@ class BetterYouTubeRss {
 	 *
 	 * @return string
 	 */
-	public function getFeedId() {
+	private function getFeedId() {
 		return $this->feedId;
 	}
 	
@@ -180,7 +180,7 @@ class BetterYouTubeRss {
 	 *
 	 * @return boolean
 	 */
-	public function getEmbedStatus() {
+	private function getEmbedStatus() {
 		return $this->embedVideos;
 	}
 
@@ -189,7 +189,7 @@ class BetterYouTubeRss {
 	 *
 	 * @return array
 	 */
-	public function getParts() {
+	private function getParts() {
 		return $this->parts;
 	}
 }


### PR DESCRIPTION
This pull request changes the visibility of the class functions `generateFeed()`, `generateIndex()`, `getFeedType()`, `getFeedId()`, `getEmbedStatus()` and `getParts()` to private.