### PR TITLE
Move cache handling to Data class

### DIFF
--- a/include/BetterYouTubeRss.class.php
+++ b/include/BetterYouTubeRss.class.php
@@ -133,18 +133,9 @@ class BetterYouTubeRss {
 	 */
 	private function generateFeed() {
 
-		$cache = new Cache(
-			$this->getFeedId()
-		);
-		$cache->load();
-
 		$data = new Data(
 			$this->getFeedId(),
 			$this->getFeedType()
-		);
-
-		$data->setData(
-			$cache->getData()
 		);
 
 		$fetch = new Fetch(
@@ -187,11 +178,6 @@ class BetterYouTubeRss {
 				);
 			}
 		}
-
-		$cache->save(
-			$data->getData(),
-			$data->getUpdateStatus()
-		);
 
 		if (!in_array($this->feedFormat, $this->getFeedFormats())) {
 			throw new Exception('Invalid format parameter given.');

--- a/include/Data.class.php
+++ b/include/Data.class.php
@@ -56,6 +56,17 @@ class Data {
 			$this->cache->getData()
 		);
 	}
+
+	/**
+	 * Destructor
+	 */
+	public function __destruct() {
+
+		// Save data to cache file, if updated
+		$this->cache->save(
+			$this->getData(),
+			$this->getUpdateStatus()
+		);
 	}
 
 	/**

--- a/include/Data.class.php
+++ b/include/Data.class.php
@@ -45,6 +45,17 @@ class Data {
 	public function __construct(string $feedId, string $feedType) {
 		$this->data['details']['id'] = $feedId;
 		$this->data['details']['type'] = $feedType;
+
+		$this->cache = new Cache($feedId);
+
+		// Load cache 
+		$this->cache->load();
+
+		// Use data from cache, if found
+		$this->setData(
+			$this->cache->getData()
+		);
+	}
 	}
 
 	/**

--- a/include/Data.class.php
+++ b/include/Data.class.php
@@ -2,6 +2,9 @@
 
 class Data {
 
+	/** @var object $cache Cache class object */
+	private $cache;
+
 	/** @var string $endpoint YouTube.com Endpoint */
 	private $endpoint = 'https://www.youtube.com';
 


### PR DESCRIPTION
This pull request moves the handling of cache loading and saving from the function `generateFeed` in `BetterYouTubeRss` to the constructor and destructor of the `Data` class.